### PR TITLE
Move Schemifier call to the bottom of boot sequence

### DIFF
--- a/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -33,11 +33,6 @@ class Boot {
       DB.defineConnectionManager(util.DefaultConnectionIdentifier, vendor)
     }
 
-    // Use Lift's Mapper ORM to populate the database
-    // you don't need to use Mapper to use Lift... use
-    // any ORM you want
-    Schemifier.schemify(true, Schemifier.infoF _, User)
-
     // where to search snippet
     LiftRules.addToPackages("$package$")
 
@@ -91,5 +86,10 @@ class Boot {
     }
     // Make a transaction span the whole HTTP request
     S.addAround(DB.buildLoanWrapper)
+
+    // Use Lift's Mapper ORM to populate the database
+    // you don't need to use Mapper to use Lift... use
+    // any ORM you want
+    Schemifier.schemify(true, Schemifier.infoF _, User)
   }
 }

--- a/src/main/g8/src/main/webapp/templates-hidden/default.html
+++ b/src/main/g8/src/main/webapp/templates-hidden/default.html
@@ -1,44 +1,23 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:lift="http://liftweb.net/">
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <meta name="description" content="" />
-    <meta name="keywords" content="" />
-    <title class="lift:Menu.title">App: </title>
-    <link href="/assets/css/app.css" rel="stylesheet" type="text/css" />
-    <style class="lift:CSS.blueprint"></style>
-    <style class="lift:CSS.fancyType"></style>
-    <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
-    <script id="json" src="/classpath/json.js" type="text/javascript"></script>
-  </head>
-  <body>
-    <div class="container">
-      <div class="column span-12 last ralign" >
-        <h1 class="alt">app</h1>
-      </div>
 
-      <hr>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <meta name="description" content="" />
+  <meta name="keywords" content="" />
+  <title>App: </title>
+  <link href="/assets/css/app.css" rel="stylesheet" type="text/css" />
+  <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
+  <script id="json" src="/classpath/json.js" type="text/javascript"></script>
+</head>
 
-      <div class="column span-6 colborder sidebar">
-        <hr class="space" >
+<body>
+  <div>
 
-	<span class="lift:Menu.builder"></span>
-
-        <div class="lift:Msgs?showAll=true"></div>
-        <hr class="space" />
-      </div>
-
-      <div class="column span-17 last">
-        <div id="content">The main content will get bound here</div>
-      </div>
-
-      <hr />
-      <div class="column span-23 last calign">
-        <h4 class="alt">
-          <a href="http://www.liftweb.net"><i>Lift</i></a>
-          is Copyright 2007-2012 WorldWide Conferencing, LLC.
-          Distributed under an Apache 2.0 License.
-        </h4>
-      </div>
+    <div>
+      <div id="content">The main content will get bound here</div>
     </div>
-  </body>
+
+  </div>
+</body>
+
 </html>

--- a/src/main/g8/src/main/webapp/templates-hidden/default.html
+++ b/src/main/g8/src/main/webapp/templates-hidden/default.html
@@ -1,23 +1,44 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:lift="http://liftweb.net/">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <title class="lift:Menu.title">App: </title>
+    <link href="/assets/css/app.css" rel="stylesheet" type="text/css" />
+    <style class="lift:CSS.blueprint"></style>
+    <style class="lift:CSS.fancyType"></style>
+    <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
+    <script id="json" src="/classpath/json.js" type="text/javascript"></script>
+  </head>
+  <body>
+    <div class="container">
+      <div class="column span-12 last ralign" >
+        <h1 class="alt">app</h1>
+      </div>
 
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-  <meta name="description" content="" />
-  <meta name="keywords" content="" />
-  <title>App: </title>
-  <link href="/assets/css/app.css" rel="stylesheet" type="text/css" />
-  <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
-  <script id="json" src="/classpath/json.js" type="text/javascript"></script>
-</head>
+      <hr>
 
-<body>
-  <div>
+      <div class="column span-6 colborder sidebar">
+        <hr class="space" >
 
-    <div>
-      <div id="content">The main content will get bound here</div>
+	<span class="lift:Menu.builder"></span>
+
+        <div class="lift:Msgs?showAll=true"></div>
+        <hr class="space" />
+      </div>
+
+      <div class="column span-17 last">
+        <div id="content">The main content will get bound here</div>
+      </div>
+
+      <hr />
+      <div class="column span-23 last calign">
+        <h4 class="alt">
+          <a href="http://www.liftweb.net"><i>Lift</i></a>
+          is Copyright 2007-2012 WorldWide Conferencing, LLC.
+          Distributed under an Apache 2.0 License.
+        </h4>
+      </div>
     </div>
-
-  </div>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
Antonio suggested that moving the Schemifier call later in the boot sequence would give better error response through the browser, if DB init fails. I tried it and it seems to work better like this.