### PR TITLE
Use Bootstrap 4 instead of Blueprint CSS

### DIFF
--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.3.12

--- a/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -81,6 +81,9 @@ class Boot {
         scriptSources = List(
             ContentSourceRestriction.Self,
             ContentSourceRestriction.UnsafeInline),
+        // Allowing style sources from all locations, since Bootstrap is now loaded from CDN.
+        // If it would be served through local resources, "ContentSourceRestriction.Self"
+        // could be used for more secure CSP restriction.
         styleSources = List(
             ContentSourceRestriction.All)
             )))

--- a/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -79,9 +79,10 @@ class Boot {
     LiftRules.securityRules = () => {
       SecurityRules(content = Some(ContentSecurityPolicy(
         scriptSources = List(
-            ContentSourceRestriction.Self),
+            ContentSourceRestriction.Self,
+            ContentSourceRestriction.UnsafeInline),
         styleSources = List(
-            ContentSourceRestriction.Self)
+            ContentSourceRestriction.All)
             )))
     }
     // Make a transaction span the whole HTTP request

--- a/src/main/g8/src/main/webapp/templates-hidden/default.html
+++ b/src/main/g8/src/main/webapp/templates-hidden/default.html
@@ -32,7 +32,7 @@
     <hr/>
     <div class="">
         <a href="http://www.liftweb.net"><i>Lift</i></a>
-        is Copyright 2007-2012 WorldWide Conferencing, LLC.
+        is Copyright 2007-2020 WorldWide Conferencing, LLC.
         Distributed under an Apache 2.0 License.
     </div>
 </div>

--- a/src/main/g8/src/main/webapp/templates-hidden/default.html
+++ b/src/main/g8/src/main/webapp/templates-hidden/default.html
@@ -1,44 +1,40 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:lift="http://liftweb.net/">
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <meta name="description" content="" />
-    <meta name="keywords" content="" />
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <meta name="description" content=""/>
+    <meta name="keywords" content=""/>
     <title class="lift:Menu.title">App: </title>
-    <link href="/assets/css/app.css" rel="stylesheet" type="text/css" />
-    <style class="lift:CSS.blueprint"></style>
-    <style class="lift:CSS.fancyType"></style>
     <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
     <script id="json" src="/classpath/json.js" type="text/javascript"></script>
-  </head>
-  <body>
-    <div class="container">
-      <div class="column span-12 last ralign" >
-        <h1 class="alt">app</h1>
-      </div>
-
-      <hr>
-
-      <div class="column span-6 colborder sidebar">
-        <hr class="space" >
-
-	<span class="lift:Menu.builder"></span>
-
-        <div class="lift:Msgs?showAll=true"></div>
-        <hr class="space" />
-      </div>
-
-      <div class="column span-17 last">
-        <div id="content">The main content will get bound here</div>
-      </div>
-
-      <hr />
-      <div class="column span-23 last calign">
-        <h4 class="alt">
-          <a href="http://www.liftweb.net"><i>Lift</i></a>
-          is Copyright 2007-2012 WorldWide Conferencing, LLC.
-          Distributed under an Apache 2.0 License.
-        </h4>
-      </div>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+          integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+    <div class="jumbotron">
+        <h1 class="alt">My Lift app</h1>
     </div>
-  </body>
+
+    <hr>
+
+    <div class="row">
+        <div class="col-sm-2">
+            <span class="lift:Menu.builder?top:class=nav+flex-column&li:class=nav-item"></span>
+
+            <div class="lift:Msgs?showAll=true"></div>
+        </div>
+        <div class="col-sm-10 border-left">
+            <div id="content">The main content will get bound here</div>
+        </div>
+    </div>
+
+    <hr/>
+    <div class="">
+        <a href="http://www.liftweb.net"><i>Lift</i></a>
+        is Copyright 2007-2012 WorldWide Conferencing, LLC.
+        Distributed under an Apache 2.0 License.
+    </div>
+</div>
+</body>
 </html>


### PR DESCRIPTION
- Changed the age old Blueprint CSS to BS 4 for better visual appearance
- Updated the default SBT version for better build experience
- Tweaked the Content Security Policy to match the current situation (no errors on the console)

The vertical navbar isn't perfect BS 4 style, as the menu builder doesn't automatically put nav-link class to the anchor, but it looks still 'OK' to my eyes at least.