### PR TITLE
Updated the template to use latest 3.5.0 of lift and Scala 2.13.6

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,7 +14,7 @@ resolvers ++= Seq(
 
 enablePlugins(JettyPlugin)
 
-unmanagedResourceDirectories in Test += baseDirectory.value / "src/main/webapp"
+Test / unmanagedResourceDirectories += baseDirectory.value / "src/main/webapp"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
@@ -24,12 +24,11 @@ libraryDependencies ++= {
   Seq(
     "net.liftweb"       %% "lift-webkit"            % liftVersion,
     "net.liftweb"       %% "lift-mapper"            % liftVersion,
-    "net.liftmodules"   %% s"lift-jquery-module_\$liftEdition" % "2.10",
     "ch.qos.logback"    % "logback-classic"         % "1.2.3",
-    "org.specs2"        %% "specs2-core"            % "3.9.4"            % "test",
+    "org.specs2"        %% "specs2-core"            % "4.12.12"            % "test",
     "com.h2database"    % "h2"                      % "1.4.187",
     "javax.servlet"     % "javax.servlet-api"       % "3.0.1"            % "provided"
   )
 }
 
-scalacOptions in Test ++= Seq("-Yrangepos")
+Test / scalacOptions ++= Seq("-Yrangepos")

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name = my-lift-app
 package = com.myco
 organization = com.myco
-lift_version = 3.3.0
-scala_version = 2.12.6
+lift_version = 3.5.0
+scala_version = 2.13.6
 verbatim = *.gif

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.5.5

--- a/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -72,6 +72,7 @@ class Boot {
     LiftRules.securityRules = () => {
       SecurityRules(content = Some(ContentSecurityPolicy(
         scriptSources = List(
+            ContentSourceRestriction.Host("https://code.jquery.com"),
             ContentSourceRestriction.Self,
             ContentSourceRestriction.UnsafeInline),
         // Allowing style sources from all locations, since Bootstrap is now loaded from CDN.

--- a/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/g8/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -6,13 +6,11 @@ import Helpers._
 
 import common._
 import http._
-import js.jquery.JQueryArtifacts
 import sitemap._
 import Loc._
 import mapper._
 
 import $package$.model._
-import net.liftmodules.JQueryModule
 
 
 /**
@@ -50,11 +48,6 @@ class Boot {
     // set the sitemap.  Note if you don't want access control for
     // each page, just comment this line out.
     LiftRules.setSiteMapFunc(() => sitemapMutators(sitemap))
-
-    //Init the jQuery module, see http://liftweb.net/jquery for more information.
-    //LiftRules.jsArtifacts = JQueryArtifacts
-    JQueryModule.InitParam.JQuery=JQueryModule.JQuery1113
-    JQueryModule.init()
 
     //Show the spinny image when an Ajax call starts
     LiftRules.ajaxStart =

--- a/src/main/g8/src/main/webapp/templates-hidden/default.html
+++ b/src/main/g8/src/main/webapp/templates-hidden/default.html
@@ -5,8 +5,7 @@
     <meta name="description" content=""/>
     <meta name="keywords" content=""/>
     <title class="lift:Menu.title">App: </title>
-    <script id="jquery" src="/classpath/jquery.js" type="text/javascript"></script>
-    <script id="json" src="/classpath/json.js" type="text/javascript"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
           integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
 </head>


### PR DESCRIPTION
Should work now out of the box and with no errors in the log, also on client side (besides the normal 404 on favicon).